### PR TITLE
Possibility to change chain identifier

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -11,9 +11,13 @@ Future<void> main() async {
   var publicKey = await keyPair.getPublicKey();
   var address = await keyPair.address;
 
+  print('Cryptography examples');
   print('entropy: ${keyStore.entropy}');
   print('private key: ${HEX.encode(privateKey!)}');
   print('public key: ${HEX.encode(publicKey)}');
   print('address: $address');
-  print('core bytes: ${HEX.encode(address!.core!)}');
+  print('core bytes: ${HEX.encode(address!.core!)}\n');
+  print('Network examples');
+  print('chain identifier: ' + getChainIdentifier().toString());
+  print('network identifier: ' + getNetworkIdentifier().toString());
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -18,6 +18,5 @@ Future<void> main() async {
   print('address: $address');
   print('core bytes: ${HEX.encode(address!.core!)}\n');
   print('Network examples');
-  print('chain identifier: ' + getChainIdentifier().toString());
-  print('network identifier: ' + getNetworkIdentifier().toString());
+  print('chain and network identifier: ' + getChainIdentifier().toString());
 }

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -58,9 +58,10 @@ void ensureDirectoriesExist() {
   return;
 }
 
+// Alphanet chain identifier as defined in the Genesis configuration file
+// Alphanet network identifier is initialized with the chain identifier
 // https://github.com/zenon-network/go-zenon/blob/b2e6a98fa154d763571bb7af6b1c685d0d82497d/zenon/zenon.go#L41
-int netId = 1; // Alphanet network identifier
-int chainId = 1; // Alphanet chain identifier
+int chainId = 1;
 
 void setChainIdentifier({int chainIdentifier = 1}) {
   chainId = chainIdentifier;
@@ -68,10 +69,6 @@ void setChainIdentifier({int chainIdentifier = 1}) {
 
 int getChainIdentifier() {
   return chainId;
-}
-
-int getNetworkIdentifier() {
-  return netId;
 }
 
 final logger = Logger('ZNN-SDK');

--- a/lib/src/global.dart
+++ b/lib/src/global.dart
@@ -58,7 +58,21 @@ void ensureDirectoriesExist() {
   return;
 }
 
-int netId = 1; // Alphanet
+// https://github.com/zenon-network/go-zenon/blob/b2e6a98fa154d763571bb7af6b1c685d0d82497d/zenon/zenon.go#L41
+int netId = 1; // Alphanet network identifier
+int chainId = 1; // Alphanet chain identifier
+
+void setChainIdentifier({int chainIdentifier = 1}) {
+  chainId = chainIdentifier;
+}
+
+int getChainIdentifier() {
+  return chainId;
+}
+
+int getNetworkIdentifier() {
+  return netId;
+}
 
 final logger = Logger('ZNN-SDK');
 

--- a/lib/src/model/nom/account_block_template.dart
+++ b/lib/src/model/nom/account_block_template.dart
@@ -58,7 +58,7 @@ class AccountBlockTemplate {
       fromBlockHash,
       data})
       : version = 1,
-        chainIdentifier = netId,
+        chainIdentifier = chainId,
         hash = emptyHash,
         previousHash = emptyHash,
         height = 0,
@@ -82,13 +82,17 @@ class AccountBlockTemplate {
           fromBlockHash: fromBlockHash);
 
   factory AccountBlockTemplate.send(
-          Address toAddress, TokenStandard tokenStandard, int amount, [List<int>? data,]) =>
+    Address toAddress,
+    TokenStandard tokenStandard,
+    int amount, [
+    List<int>? data,
+  ]) =>
       AccountBlockTemplate(
-          blockType: BlockTypeEnum.userSend.index,
-          toAddress: toAddress,
-          tokenStandard: tokenStandard,
-          amount: amount,
-          data: data,
+        blockType: BlockTypeEnum.userSend.index,
+        toAddress: toAddress,
+        tokenStandard: tokenStandard,
+        amount: amount,
+        data: data,
       );
 
   factory AccountBlockTemplate.callContract(Address toAddress,


### PR DESCRIPTION
The `netId` field is irrelevant from a client perspective. Also `go-zenon` uses `netId` and `chainId` [interchangeably](https://github.com/zenon-network/go-zenon/blob/b2e6a98fa154d763571bb7af6b1c685d0d82497d/zenon/zenon.go#L41). 