### PR TITLE
Generalize `KeyFile` to `EncryptedFile`

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -9,14 +9,14 @@ Future<void> main() async {
   var keyPair = keyStore.getKeyPair(0);
   var privateKey = keyPair.getPrivateKey();
   var publicKey = await keyPair.getPublicKey();
-  var address = await keyPair.address;
+  var address = await keyPair.getAddress();
 
   print('Cryptography examples');
   print('entropy: ${keyStore.entropy}');
   print('private key: ${HEX.encode(privateKey!)}');
   print('public key: ${HEX.encode(publicKey)}');
   print('address: $address');
-  print('core bytes: ${HEX.encode(address!.core!)}\n');
+  print('core bytes: ${HEX.encode(address.core!)}\n');
   print('Network examples');
   print('chain and network identifier: ' + getChainIdentifier().toString());
 }

--- a/lib/src/wallet/constants.dart
+++ b/lib/src/wallet/constants.dart
@@ -1,0 +1,6 @@
+// Metadata
+const String baseAddressKey = 'baseAddress';
+const String walletTypeKey = 'walletType';
+
+// KeyStore
+const String keyStoreWalletType = 'keystore';

--- a/lib/src/wallet/encryptedfile.dart
+++ b/lib/src/wallet/encryptedfile.dart
@@ -8,15 +8,18 @@ import 'package:hex/hex.dart';
 import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class EncryptedFile {
+  Map<String, dynamic>? metadata;
   _Crypto? crypto;
   int? timestamp;
   int? version;
 
-  EncryptedFile({this.crypto, this.timestamp, this.version});
+  EncryptedFile({this.metadata, this.crypto, this.timestamp, this.version});
 
-  static Future<EncryptedFile> encrypt(List<int> data, String password) async {
+  static Future<EncryptedFile> encrypt(List<int> data, String password,
+      {Map<String, dynamic>? metadata}) async {
     var timestamp = ((DateTime.now()).millisecondsSinceEpoch / 1000).round();
     var stored = EncryptedFile(
+        metadata: metadata,
         timestamp: timestamp,
         version: 1,
         crypto: _Crypto(
@@ -59,13 +62,16 @@ class EncryptedFile {
   }
 
   EncryptedFile.fromJson(Map<String, dynamic> json) {
-    crypto = json['crypto'] != null ? _Crypto.fromJson(json['crypto']) : null;
-    timestamp = json['timestamp'];
-    version = json['version'];
+    final data = {...json};
+    crypto =
+        json['crypto'] != null ? _Crypto.fromJson(data.remove('crypto')) : null;
+    timestamp = data.remove('timestamp');
+    version = data.remove('version');
+    metadata = data.isNotEmpty ? {...data} : null;
   }
 
   Map<String, dynamic> toJson() {
-    final data = <String, dynamic>{};
+    final data = metadata != null ? {...metadata!} : <String, dynamic>{};
     if (crypto != null) {
       data['crypto'] = crypto!.toJson();
     }

--- a/lib/src/wallet/exceptions.dart
+++ b/lib/src/wallet/exceptions.dart
@@ -1,9 +1,9 @@
 import 'package:znn_sdk_dart/src/global.dart';
 
-class InvalidWalletPath implements Exception {
+class WalletException implements Exception {
   String message;
 
-  InvalidWalletPath(this.message);
+  WalletException(this.message);
 
   @override
   String toString() {

--- a/lib/src/wallet/exceptions.dart
+++ b/lib/src/wallet/exceptions.dart
@@ -1,9 +1,9 @@
 import 'package:znn_sdk_dart/src/global.dart';
 
-class InvalidKeyStorePath implements Exception {
+class InvalidWalletPath implements Exception {
   String message;
 
-  InvalidKeyStorePath(this.message);
+  InvalidWalletPath(this.message);
 
   @override
   String toString() {

--- a/lib/src/wallet/keypair.dart
+++ b/lib/src/wallet/keypair.dart
@@ -4,7 +4,7 @@ import 'package:znn_sdk_dart/src/crypto/crypto.dart';
 import 'package:znn_sdk_dart/src/model/primitives.dart';
 import 'package:znn_sdk_dart/src/wallet/interfaces.dart';
 import 'package:znn_sdk_dart/src/model/nom/account_block_template.dart';
-import 'package:znn_sdk_dart/src/utils/block.dart';
+
 class KeyPair implements WalletAccount {
   List<int>? privateKey;
   List<int>? publicKey;

--- a/lib/src/wallet/keystore.dart
+++ b/lib/src/wallet/keystore.dart
@@ -16,7 +16,7 @@ class KeyStoreDefinition implements WalletDefinition {
 
   KeyStoreDefinition({required this.file}) {
     if (!file.existsSync()) {
-      throw InvalidKeyStorePath('Given keyStore does not exist ($file)');
+      throw InvalidWalletPath('Given keyStore does not exist ($file)');
     }
   }
 

--- a/lib/src/wallet/keystore.dart
+++ b/lib/src/wallet/keystore.dart
@@ -16,7 +16,7 @@ class KeyStoreDefinition implements WalletDefinition {
 
   KeyStoreDefinition({required this.file}) {
     if (!file.existsSync()) {
-      throw InvalidWalletPath('Given keyStore does not exist ($file)');
+      throw WalletException('Given keyStore does not exist ($file)');
     }
   }
 

--- a/lib/src/wallet/manager.dart
+++ b/lib/src/wallet/manager.dart
@@ -84,7 +84,7 @@ class KeyStoreManager implements WalletManager {
 
   Future<KeyStore> readKeyStore(String password, File keyStoreFile) async {
     if (!keyStoreFile.existsSync()) {
-      throw InvalidKeyStorePath(
+      throw InvalidWalletPath(
           'Given keyStore does not exist ($keyStoreFile)');
     }
 
@@ -100,7 +100,7 @@ class KeyStoreManager implements WalletManager {
         if (file is File) {
           return KeyStoreDefinition(file: file);
         } else {
-          throw InvalidKeyStorePath('Given keyStore is not a file ($name)');
+          throw InvalidWalletPath('Given keyStore is not a file ($name)');
         }
       }
     }

--- a/lib/src/wallet/manager.dart
+++ b/lib/src/wallet/manager.dart
@@ -33,7 +33,6 @@ void saveKeyStoreFunction(SaveKeyStoreArguments args) async {
 
 class KeyStoreManager implements WalletManager {
   final Directory walletPath;
-  KeyStore? keyStoreInUse;
 
   KeyStoreManager({required this.walletPath});
 
@@ -69,17 +68,6 @@ class KeyStoreManager implements WalletManager {
       }
     });
     return completer.future;
-  }
-
-  void setKeyStore(KeyStore keyStore) {
-    keyStoreInUse = keyStore;
-  }
-
-  String? getMnemonicInUse() {
-    if (keyStoreInUse == null) {
-      throw ArgumentError('The keyStore in use is null');
-    }
-    return keyStoreInUse!.mnemonic;
   }
 
   Future<KeyStore> readKeyStore(String password, File keyStoreFile) async {

--- a/lib/src/wallet/wallet.dart
+++ b/lib/src/wallet/wallet.dart
@@ -1,3 +1,4 @@
+export 'constants.dart';
 export 'derivation.dart';
 export 'encryptedfile.dart';
 export 'exceptions.dart';

--- a/lib/src/wallet/wallet.dart
+++ b/lib/src/wallet/wallet.dart
@@ -1,6 +1,6 @@
 export 'derivation.dart';
+export 'encryptedfile.dart';
 export 'exceptions.dart';
-export 'keyfile.dart';
 export 'keypair.dart';
 export 'keystore.dart';
 export 'manager.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: znn_sdk_dart
 description: Zenon SDK for Dart and Flutter
-version: 0.0.6
+version: 0.0.7
 
 environment:
   sdk: '>=2.14.0 <3.0.0'

--- a/test/wallet/encryptedfile_metadata_test.dart
+++ b/test/wallet/encryptedfile_metadata_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:znn_sdk_dart/znn_sdk_dart.dart';
+
+void main() async {
+  var keyStoreString = '''
+  {
+    "crypto": {
+        "argon2Params": {
+          "salt": "0x5b85100f186953332faddeaf2b6d68de"
+        },
+        "cipherData": "0xcfe2e1aa498229aaf78ab9634592a19c1f45ad5178ed4d530fdeef8fe528e4b78955a389e0d1e832fd0c21346b3a45cd",
+        "cipherName": "aes-256-gcm",
+        "kdf": "argon2.IDKey",
+        "nonce": "0x86d6b27ba67a72238af12958"
+      },
+    "timestamp": 1707418422,
+    "version": 1
+  }
+  ''';
+  var keyStoreStringWithMeta = '''
+  {
+    "baseAddress": "z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7",
+    "walletType": "keystore",
+    "crypto": {
+        "argon2Params": {
+          "salt": "0x5b85100f186953332faddeaf2b6d68de"
+        },
+        "cipherData": "0xcfe2e1aa498229aaf78ab9634592a19c1f45ad5178ed4d530fdeef8fe528e4b78955a389e0d1e832fd0c21346b3a45cd",
+        "cipherName": "aes-256-gcm",
+        "kdf": "argon2.IDKey",
+        "nonce": "0x86d6b27ba67a72238af12958"
+      },
+    "timestamp": 1707418422,
+    "version": 1
+  }
+  ''';
+  var encryptedFile = EncryptedFile.fromJson(jsonDecode(keyStoreString));
+  test('same json', () {
+    expect(encryptedFile.toJson(), jsonDecode(keyStoreString));
+  });
+  test('same metadata', () {
+    expect(encryptedFile.metadata, null);
+  });
+
+  var encryptedFileWithMeta =
+      EncryptedFile.fromJson(jsonDecode(keyStoreStringWithMeta));
+  test('same json', () {
+    expect(encryptedFileWithMeta.toJson(), jsonDecode(keyStoreStringWithMeta));
+  });
+  test('same metadata', () {
+    expect(encryptedFileWithMeta.metadata, {
+      "baseAddress": "z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7",
+      "walletType": "keystore",
+    });
+  });
+}


### PR DESCRIPTION
This PR contains a generalization of the `KeyFile` and `InvalidKeyStorePath` class.

# Generalize `KeyFile` to `EncryptedFile`

The `KeyFile` can be used multifunctionally if the `KeyStore` part is removed from the `KeyFile` class. The key file then changes into a non-specific encrypted file.

The calling party then becomes responsible for encoding and decoding the encrypted data, rather than the key file itself.

The key file contained a `baseAddress` field that was not used. Instead of resolving the `baseAddress` directly within the implementation, It now accepts a metadata argument, containing key/value pairs. This keeps the class generalized and allows the addition of a `walletType` property to solve the issue of differiating between different wallet types.

Encrypted files for hardware wallets store different data than keystore wallets. The keystore manager will validate the correct wallet type only if the field is present in the metadata; otherwise it assumes its a `KeyStore`.

# Other changes

- Remove unused import
- Rename `InvalidKeyStorePath` to `WalletException`
- Make `KeyStoreManager` stateless
- Add unit test for `EncryptedFile`
- Update example