### PR TITLE
Add toJson methods, override equals and hashCode methods for some data classes

### DIFF
--- a/lib/src/api/api.dart
+++ b/lib/src/api/api.dart
@@ -1,3 +1,4 @@
+export 'embedded/embedded.dart';
 export 'embedded.dart';
 export 'ledger.dart';
 export 'stats.dart';

--- a/lib/src/api/embedded/embedded.dart
+++ b/lib/src/api/embedded/embedded.dart
@@ -1,0 +1,11 @@
+export 'accelerator.dart';
+export 'bridge.dart';
+export 'htlc.dart';
+export 'liquidity.dart';
+export 'pillar.dart';
+export 'plasma.dart';
+export 'sentinel.dart';
+export 'spork.dart';
+export 'stake.dart';
+export 'swap.dart';
+export 'token.dart';

--- a/lib/src/model/embedded/pillar.dart
+++ b/lib/src/model/embedded/pillar.dart
@@ -148,9 +148,20 @@ class DelegationInfo {
       );
 
   Map<String, dynamic> toJson() =>
-      {'name': name, 'status': status, 'weight': weight};
+      {'name': name, 'status': status, 'weight': weight.toString()};
 
   bool isPillarActive() {
     return status == 1;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      other is DelegationInfo &&
+          other.runtimeType == runtimeType &&
+          other.name == name &&
+          other.status == status &&
+          other.weight.toString() == weight.toString();
+
+  @override
+  int get hashCode => Object.hash(name, status, weight);
 }

--- a/lib/src/model/embedded/sentinel.dart
+++ b/lib/src/model/embedded/sentinel.dart
@@ -1,6 +1,7 @@
+import 'package:equatable/equatable.dart';
 import 'package:znn_sdk_dart/src/model/primitives.dart';
 
-class SentinelInfo {
+class SentinelInfo extends Equatable {
   Address owner;
   int registrationTimestamp;
   bool isRevocable;
@@ -21,9 +22,18 @@ class SentinelInfo {
         'revokeCooldown': revokeCooldown,
         'active': active
       };
+
+  @override
+  List<Object?> get props => [
+        active,
+        isRevocable,
+        owner,
+        registrationTimestamp,
+        revokeCooldown,
+      ];
 }
 
-class SentinelInfoList {
+class SentinelInfoList extends Equatable {
   int count;
   List<SentinelInfo> list;
 
@@ -37,4 +47,7 @@ class SentinelInfoList {
 
   Map<String, dynamic> toJson() =>
       {'count': count, 'list': list.map((v) => v.toJson()).toList()};
+
+  @override
+  List<Object?> get props => [count, list];
 }

--- a/lib/src/model/embedded/stake.dart
+++ b/lib/src/model/embedded/stake.dart
@@ -1,6 +1,7 @@
+import 'package:equatable/equatable.dart';
 import 'package:znn_sdk_dart/src/model/primitives.dart';
 
-class StakeList {
+class StakeList extends Equatable {
   BigInt totalAmount;
   BigInt totalWeightedAmount;
   int count;
@@ -29,9 +30,17 @@ class StakeList {
 
     return data;
   }
+
+  @override
+  List<Object?> get props => [
+        count,
+        list,
+        totalAmount,
+        totalWeightedAmount,
+      ];
 }
 
-class StakeEntry {
+class StakeEntry extends Equatable {
   final BigInt amount;
   final BigInt weightedAmount;
   final int startTimestamp;
@@ -66,4 +75,14 @@ class StakeEntry {
 
     return data;
   }
+
+  @override
+  List<Object?> get props => [
+        address,
+        amount,
+        expirationTimestamp,
+        id,
+        startTimestamp,
+        weightedAmount,
+      ];
 }

--- a/lib/src/model/embedded/stake.dart
+++ b/lib/src/model/embedded/stake.dart
@@ -19,6 +19,16 @@ class StakeList {
         list = (json['list'] as List)
             .map((entry) => StakeEntry.fromJson(entry))
             .toList();
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['totalAmount'] = totalAmount.toString();
+    data['totalWeightedAmount'] = totalWeightedAmount.toString();
+    data['count'] = count;
+    data['list'] = list.map((entry) => entry.toJson()).toList();
+
+    return data;
+  }
 }
 
 class StakeEntry {
@@ -44,4 +54,16 @@ class StakeEntry {
       expirationTimestamp: json['expirationTimestamp'],
       address: Address.parse(json['address']),
       id: Hash.parse(json['id']));
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['amount'] = amount.toString();
+    data['weightedAmount'] = weightedAmount.toString();
+    data['startTimestamp'] = startTimestamp;
+    data['expirationTimestamp'] = expirationTimestamp;
+    data['address'] = address.toString();
+    data['hash'] = id.toString();
+
+    return data;
+  }
 }

--- a/lib/src/model/embedded/stake.dart
+++ b/lib/src/model/embedded/stake.dart
@@ -62,7 +62,7 @@ class StakeEntry {
     data['startTimestamp'] = startTimestamp;
     data['expirationTimestamp'] = expirationTimestamp;
     data['address'] = address.toString();
-    data['hash'] = id.toString();
+    data['id'] = id.toString();
 
     return data;
   }

--- a/lib/src/model/nom/account_block.dart
+++ b/lib/src/model/nom/account_block.dart
@@ -1,7 +1,8 @@
+import 'package:equatable/equatable.dart';
 import 'package:znn_sdk_dart/src/model/model.dart';
 import 'package:znn_sdk_dart/src/model/primitives/hash.dart';
 
-class AccountBlockConfirmationDetail {
+class AccountBlockConfirmationDetail extends Equatable {
   int numConfirmations;
   int momentumHeight;
   Hash momentumHash;
@@ -21,6 +22,14 @@ class AccountBlockConfirmationDetail {
     data['momentumTimestamp'] = momentumTimestamp;
     return data;
   }
+
+  @override
+  List<Object?> get props => [
+    numConfirmations,
+    momentumHeight,
+    momentumHash,
+    momentumTimestamp,
+  ];
 }
 
 class AccountBlock extends AccountBlockTemplate {

--- a/lib/src/model/nom/account_block_template.dart
+++ b/lib/src/model/nom/account_block_template.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:znn_sdk_dart/src/global.dart';
 import 'package:znn_sdk_dart/src/model/primitives.dart';
 import 'package:znn_sdk_dart/src/utils/utils.dart';
@@ -16,7 +17,7 @@ extension BlockTypeEnumExtension on BlockTypeEnum {
       toString().compareTo(blockTypeEnum.toString());
 }
 
-class AccountBlockTemplate {
+class AccountBlockTemplate extends Equatable {
   int version;
   int chainIdentifier;
   int blockType;
@@ -161,4 +162,26 @@ class AccountBlockTemplate {
   String toString() {
     return toJson().toString();
   }
+
+  @override
+  List<Object?> get props => [
+        version,
+        chainIdentifier,
+        blockType,
+        hash,
+        previousHash,
+        height,
+        momentumAcknowledged,
+        address,
+        toAddress,
+        amount,
+        tokenStandard,
+        fromBlockHash,
+        data,
+        fusedPlasma,
+        difficulty,
+        nonce,
+        publicKey,
+        signature,
+      ];
 }

--- a/lib/src/model/nom/account_info.dart
+++ b/lib/src/model/nom/account_info.dart
@@ -21,6 +21,21 @@ class AccountInfo {
         : [];
   }
 
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    if (address != null) {
+      data['address'] = address;
+    }
+    if (blockCount != null) {
+      data['accountHeight'] = blockCount;
+    }
+    if (balanceInfoList != null) {
+      data['balanceInfoMap'] =
+          balanceInfoList!.map((item) => item.toJson()).toList();
+    }
+    return data;
+  }
+
   BigInt? znn() => getBalance(znnZts);
 
   BigInt? qsr() => getBalance(qsrZts);

--- a/lib/src/model/nom/account_info.dart
+++ b/lib/src/model/nom/account_info.dart
@@ -1,8 +1,9 @@
 import 'package:collection/collection.dart' show IterableExtension;
+import 'package:equatable/equatable.dart';
 import 'package:znn_sdk_dart/src/model/nom.dart';
 import 'package:znn_sdk_dart/src/model/primitives.dart';
 
-class AccountInfo {
+class AccountInfo extends Equatable {
   String? address;
   int? blockCount;
   List<BalanceInfoListItem>? balanceInfoList;
@@ -61,9 +62,12 @@ class AccountInfo {
       return null;
     }
   }
+
+  @override
+  List<Object?> get props => [address, blockCount, balanceInfoList];
 }
 
-class BalanceInfoListItem {
+class BalanceInfoListItem extends Equatable {
   Token? token;
   BigInt? balance;
 
@@ -83,4 +87,7 @@ class BalanceInfoListItem {
     data['balance'] = balance.toString();
     return data;
   }
+
+  @override
+  List<Object?> get props => [token, balance];
 }

--- a/lib/src/model/nom/account_info.dart
+++ b/lib/src/model/nom/account_info.dart
@@ -30,8 +30,12 @@ class AccountInfo {
       data['accountHeight'] = blockCount;
     }
     if (balanceInfoList != null) {
-      data['balanceInfoMap'] =
-          balanceInfoList!.map((item) => item.toJson()).toList();
+      final Iterable<String> keys =
+          balanceInfoList!.map((e) => e.token!.tokenStandard.toString());
+      final Iterable<Map<String, dynamic>> values =
+          balanceInfoList!.map((e) => e.toJson());
+      final Map<String, dynamic> finalMap = Map.fromIterables(keys, values);
+      data['balanceInfoMap'] = finalMap;
     }
     return data;
   }

--- a/lib/src/model/primitives/address.dart
+++ b/lib/src/model/primitives/address.dart
@@ -82,6 +82,7 @@ class Address {
         DeepCollectionEquality().equals(core, address.core);
   }
 
+  @override
   bool operator ==(Object other) =>
       other is Address &&
       other.runtimeType == runtimeType &&

--- a/lib/src/model/primitives/hash.dart
+++ b/lib/src/model/primitives/hash.dart
@@ -39,21 +39,14 @@ class Hash {
         longString.substring(longString.length - 6);
   }
 
-  bool equals(Hash hash) {
-    if (this == hash) {
-      return true;
-    }
-
-    return DeepCollectionEquality().equals(this.getBytes(), hash.getBytes());
-  }
-
   int compareTo(Hash otherHash) =>
       hash.toString().compareTo(otherHash.toString());
 
+  @override
   bool operator ==(Object other) =>
       other is Hash &&
       other.runtimeType == runtimeType &&
-      other.toString() == toString();
+      DeepCollectionEquality().equals(this.getBytes(), other.getBytes());
 
   @override
   int get hashCode => toString().hashCode;

--- a/lib/src/model/primitives/hash_height.dart
+++ b/lib/src/model/primitives/hash_height.dart
@@ -1,9 +1,10 @@
+import 'package:equatable/equatable.dart';
 import 'package:znn_sdk_dart/src/model/primitives.dart';
 import 'package:znn_sdk_dart/src/utils/bytes.dart';
 
 final emptyHashHeight = HashHeight(emptyHash, 0);
 
-class HashHeight {
+class HashHeight extends Equatable {
   Hash? hash;
   int? height;
 
@@ -28,4 +29,7 @@ class HashHeight {
     return BytesUtils.merge(
         [hash!.getBytes(), BytesUtils.longToBytes(height!)]);
   }
+
+  @override
+  List<Object?> get props => [hash, height];
 }

--- a/lib/src/model/stats.dart
+++ b/lib/src/model/stats.dart
@@ -63,4 +63,13 @@ class SyncInfo {
       : state = SyncState.values[json['state'] ?? 0],
         currentHeight = json['currentHeight'],
         targetHeight = json['targetHeight'];
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['state'] = state.index;
+    data['currentHeight'] = currentHeight;
+    data['targetHeight'] = targetHeight;
+
+    return data;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  equatable: ^2.0.5
   bip39: ^1.0.6
   hex: ^0.2.0
   bip32: ^2.0.0


### PR DESCRIPTION
As specified in the PR request - https://github.com/zenon-network/syrius/pull/131 - for the Zenon app, I've used HydratedCubits. These cubits serialize and deserialize the state of a cubit to saved it and restore it. This means that all the objects used in a state must have toJson and fromJson methods. Some classes in the SDK don't have one, so I had to add them.

For the unit tests to pass, correct equality between two instances of the same class had to be implemented.

For bigger classes, I've used the equatable package - https://pub.dev/packages/equatable - so I won't be needed to write a lot of code.